### PR TITLE
Fix url to include *.signed.dmg

### DIFF
--- a/Casks/insomnium.rb
+++ b/Casks/insomnium.rb
@@ -2,7 +2,7 @@ cask "insomnium" do
   version "0.2.3-a"
   sha256 "71575c907345320fa620b9975e84ff448be5704f81c9a8aeaa5fbf46ff4fef09"
 
-  url "https://github.com/ArchGPT/insomnium/releases/download/core%40#{version}/Insomnium.Core-#{version}.dmg",
+  url "https://github.com/ArchGPT/insomnium/releases/download/core%40#{version}/Insomnium.Core-#{version}.signed.dmg",
       verified: "github.com/ArchGPT/insomnium/"
   name "Insomnium"
   desc "HTTP & GraphQL Client. FOSS Fork of Insomnia. 100%-Local, no user login, etc"


### PR DESCRIPTION
This is a fix to make it work with `Insomnium 0.2.3-a` release as the url changed when it was signed.